### PR TITLE
Fix Back:trigger_effect hook

### DIFF
--- a/HoldForFinalHandScore.lua
+++ b/HoldForFinalHandScore.lua
@@ -33,7 +33,7 @@ function Back:trigger_effect(args)
       end
     }))
   end
-  return back_trigger_effects_ref(args)
+  return back_trigger_effects_ref(self, args)
 end
 
 -- Pause on hand chip total.


### PR DESCRIPTION
Fixes an issue in the `Back:trigger_effect` hook where the original function does not get called properly:
+ Fixes a mod compatibility with my mod (and any other mod that hooks this function): https://github.com/larswijn/CardSleeves/issues/3.
+ Fixes Anaglyph and Plasma deck not functioning properly: #2 and #3.